### PR TITLE
Add birthday email function and command

### DIFF
--- a/app/Console/Commands/SendBirthdayEmails.php
+++ b/app/Console/Commands/SendBirthdayEmails.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Http\Controllers\ClientController;
+
+class SendBirthdayEmails extends Command
+{
+    protected $signature = 'SendBirthdayEmails';
+    protected $description = 'Send birthday emails to clients';
+
+    public function handle()
+    {
+        $response = ClientController::sendBirthdayEmails();
+        $data = $response->getData(true);
+        $emails = $data['emailed'] ?? [];
+
+        if (empty($emails)) {
+            $this->info('No birthday emails sent.');
+        } else {
+            $this->info('Birthday emails sent to: ' . implode(', ', $emails));
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -29,8 +29,12 @@ class Kernel extends ConsoleKernel
                  ->runInBackground();
 
         $schedule->command('worldtravel:send-passport-expiry-notification')
-				->daily()
-				->runInBackground();
+                                ->daily()
+                                ->runInBackground();
+
+        $schedule->command('SendBirthdayEmails')
+                 ->daily()
+                 ->runInBackground();
     }
 
     /**

--- a/app/Mail/BirthdayWishMail.php
+++ b/app/Mail/BirthdayWishMail.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Mail;
+
+use App\Client;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class BirthdayWishMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    public function build()
+    {
+        return $this->subject('Happy Birthday!')
+                    ->view('mails.birthday')
+                    ->with(['client' => $this->client]);
+    }
+}

--- a/resources/views/mails/birthday.blade.php
+++ b/resources/views/mails/birthday.blade.php
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Happy Birthday</title>
+</head>
+<body>
+    <p>Happy Birthday, {{ $client->fullname }}!</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- send happy birthday emails using new `BirthdayWishMail`
- command `SendBirthdayEmails` to trigger the email routine daily
- schedule birthday email command
- add simple birthday email blade view

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: PHP version requirements)*

------
https://chatgpt.com/codex/tasks/task_e_6878f09ce7188323812e57634f694b45