### PR TITLE
Fix birthday email query

### DIFF
--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -257,7 +257,9 @@ class ClientController extends Controller
 
     /**
      * Check clients birthdays and send greeting emails.
-     * This method is intended to be executed daily via scheduler.
+     * This method reads each client's `date_of_birth` column to
+     * determine if today is their birthday. It is intended to run daily
+     * via the scheduler.
      *
      * @return \Illuminate\Http\JsonResponse
      */
@@ -267,10 +269,10 @@ class ClientController extends Controller
 
         $emailed = [];
 
-        $clients = Client::whereNotNull('birthday')->get();
+        $clients = Client::whereNotNull('date_of_birth')->get();
 
         foreach ($clients as $client) {
-            if (Carbon::parse($client->birthday)->format('m-d') === $today) {
+            if (Carbon::parse($client->date_of_birth)->format('m-d') === $today) {
                 $cacheKey = 'birthday_email_'.$client->id.'_'.Carbon::now()->toDateString();
 
                 if (!Cache::has($cacheKey)) {


### PR DESCRIPTION
## Summary
- adjust birthday email job to use `date_of_birth` column
- clarify docblock

## Testing
- `composer install --ignore-platform-reqs` *(fails: network restrictions)*
- `php artisan SendBirthdayEmails` *(fails: missing vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_687908547c3483238783459dfa96feaa