### PR TITLE
Update schedule to use command strings

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -4,18 +4,9 @@ namespace App\Console;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
-use App\Console\Commands\SendBirthdayEmails;
 
 class Kernel extends ConsoleKernel
 {
-    /**
-     * The Artisan commands provided by your application.
-     *
-     * @var array
-     */
-    protected $commands = [
-        SendBirthdayEmails::class,
-    ];
 
     /**
      * Define the application's command schedule.
@@ -25,7 +16,11 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command(SendBirthdayEmails::class)
+        $schedule->command('SendBirthdayEmails')
+                 ->daily()
+                 ->runInBackground();
+
+        $schedule->command('SendPassportExpiryNotifications')
                  ->daily()
                  ->runInBackground();
     }


### PR DESCRIPTION
## Summary
- schedule `SendBirthdayEmails` and `SendPassportExpiryNotifications` via their command strings
- drop command class imports and explicit registration

## Testing
- `composer install` *(fails: Root composer.json requires php ^7.1.3 but your php version (8.4.10) does not satisfy that requirement)*

------
https://chatgpt.com/codex/tasks/task_e_687a2c8bc80483238acd93baa2c73c52