### PR TITLE
Add passport expiry notification command

### DIFF
--- a/app/Console/Commands/SendPassportExpiryNotifications.php
+++ b/app/Console/Commands/SendPassportExpiryNotifications.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Client;
+use App\User;
+use Carbon\Carbon;
+use App\Notifications\PassportExpiry;
+
+class SendPassportExpiryNotifications extends Command
+{
+    protected $signature = 'SendPassportExpiryNotifications';
+    protected $description = 'Send passport expiry notifications to clients and admin';
+
+    public function handle()
+    {
+        $expiryDate = Carbon::now()->addDays(env('PASSPORT_EXPIRY_DAYS', 30))->toDateString();
+
+        $clients = Client::whereDate('expiry_date', $expiryDate)->get();
+        $admin = User::where('is_superadmin', 1)->first();
+
+        foreach ($clients as $client) {
+            $client->notify(new PassportExpiry($client->fullname));
+
+            if ($admin) {
+                $admin->notify(new PassportExpiry($client->fullname));
+            }
+        }
+
+        $this->info('Passport expiry notifications sent: ' . $clients->count());
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -5,6 +5,7 @@ namespace App\Console;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 use App\Console\Commands\SendBirthdayEmails;
+use App\Console\Commands\SendPassportExpiryNotifications;
 
 class Kernel extends ConsoleKernel
 {
@@ -15,6 +16,7 @@ class Kernel extends ConsoleKernel
      */
     protected $commands = [
         SendBirthdayEmails::class,
+        SendPassportExpiryNotifications::class,
     ];
 
     /**
@@ -26,6 +28,10 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         $schedule->command(SendBirthdayEmails::class)
+                 ->daily()
+                 ->runInBackground();
+
+        $schedule->command('SendPassportExpiryNotifications')
                  ->daily()
                  ->runInBackground();
     }

--- a/app/Notifications/PassportExpiry.php
+++ b/app/Notifications/PassportExpiry.php
@@ -32,10 +32,11 @@ class PassportExpiry extends Notification
      */
     public function via($notifiable)
     {
-        if($notifiable instanceof Client)
+        if ($notifiable instanceof Client || $notifiable instanceof \App\User) {
             return ['mail'];
-        else
-            return ['database'];
+        }
+
+        return ['database'];
     }
 
     /**

--- a/tests/Unit/SendPassportExpiryNotificationsTest.php
+++ b/tests/Unit/SendPassportExpiryNotificationsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Artisan;
+use Carbon\Carbon;
+use App\User;
+use App\Client;
+use App\Notifications\PassportExpiry;
+
+class SendPassportExpiryNotificationsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['database.default' => 'sqlite']);
+        config(['database.connections.sqlite.database' => ':memory:']);
+    }
+
+    public function test_command_dispatches_notifications()
+    {
+        $this->artisan('migrate');
+
+        Notification::fake();
+
+        $admin = User::create([
+            'first_name' => 'Admin',
+            'last_name' => 'User',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('password'),
+            'is_superadmin' => 1,
+            'is_active' => 1,
+        ]);
+
+        $client = Client::create([
+            'fullname' => 'Test Client',
+            'email' => 'client@example.com',
+            'type' => 'Customer',
+            'expiry_date' => Carbon::now()->addDays(env('PASSPORT_EXPIRY_DAYS', 30))->toDateString(),
+        ]);
+
+        Artisan::call('SendPassportExpiryNotifications');
+
+        Notification::assertSentTo($client, PassportExpiry::class);
+        Notification::assertSentTo($admin, PassportExpiry::class);
+    }
+}


### PR DESCRIPTION
## Summary
- create `SendPassportExpiryNotifications` console command
- register the command and schedule it daily
- send mail notifications to admin and clients
- update notification logic to allow sending to users
- add unit test for the command

## Testing
- `composer install --no-interaction --no-progress --ignore-platform-reqs` *(fails: CONNECT tunnel failed)*
- `./vendor/bin/phpunit --testsuite Unit --stop-on-failure` *(not run due to missing vendor binaries)*

------
https://chatgpt.com/codex/tasks/task_e_687a2c8ac9508323928c0a95d8a5ddb7